### PR TITLE
[ADD] Parser customization

### DIFF
--- a/.github/workflows/type_checks.yml
+++ b/.github/workflows/type_checks.yml
@@ -53,4 +53,4 @@ jobs:
 
       # Run mypy.
       - name: Run MyPy
-        run: poetry run mypy -m py2ts_generator
+        run: poetry run mypy -p py2ts_generator

--- a/py2ts_generator/generation_pipeline/typescript_generation_pipeline.py
+++ b/py2ts_generator/generation_pipeline/typescript_generation_pipeline.py
@@ -3,11 +3,15 @@ from pathlib import Path
 from typing import List, Optional, Type, Dict, Union
 
 from py2ts_generator.model.model import Model
-from py2ts_generator.model_parser.class_parsers.abstract_class_parser import AbstractClassParser
+from py2ts_generator.model_parser.class_parsers.abstract_class_parser import (
+    AbstractClassParser,
+)
 from py2ts_generator.model_parser.class_parsers.dataclass_parser import (
     DataclassParser,
 )
-from py2ts_generator.model_parser.class_parsers.sqlalchemy_parser import SQLAlchemyParser
+from py2ts_generator.model_parser.class_parsers.sqlalchemy_parser import (
+    SQLAlchemyParser,
+)
 from py2ts_generator.model_parser.model_parser import (
     ModelParser,
     ModelParserSettings,

--- a/py2ts_generator/generation_pipeline/typescript_generation_pipeline.py
+++ b/py2ts_generator/generation_pipeline/typescript_generation_pipeline.py
@@ -1,11 +1,13 @@
 import os
 from pathlib import Path
-from typing import List, Type, Dict, Union
+from typing import List, Optional, Type, Dict, Union
 
 from py2ts_generator.model.model import Model
+from py2ts_generator.model_parser.class_parsers.abstract_class_parser import AbstractClassParser
 from py2ts_generator.model_parser.class_parsers.dataclass_parser import (
     DataclassParser,
 )
+from py2ts_generator.model_parser.class_parsers.sqlalchemy_parser import SQLAlchemyParser
 from py2ts_generator.model_parser.model_parser import (
     ModelParser,
     ModelParserSettings,
@@ -28,11 +30,13 @@ class TypeGenerationPipeline:
         type_overrides: Dict[Type, Type],
         case_format: CaseFormat,
         output_file: Union[str, Path],
+        class_parsers: Optional[List[AbstractClassParser]] = None,
     ):
         self.types = types
         self.type_overrides = type_overrides
         self.case_format = case_format
         self.output_file = output_file
+        self.class_parsers = class_parsers or [DataclassParser(), SQLAlchemyParser()]
 
     def run(self) -> None:
         model = self._parse_model()

--- a/py2ts_generator/generation_pipeline/typescript_generation_pipeline_builder.py
+++ b/py2ts_generator/generation_pipeline/typescript_generation_pipeline_builder.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import List, Self, Type, Dict, Optional
+from typing import List, Type, Dict, Optional
 
 from py2ts_generator.generation_pipeline.typescript_generation_pipeline import (
     TypeGenerationPipeline,
@@ -27,23 +27,27 @@ class TypeGenerationPipelineBuilder:
         self._output_file: Optional[str | Path] = None
         self._class_parsers: Optional[List[AbstractClassParser]] = None
 
-    def for_types(self, types: List[Type]) -> 'TypeGenerationPipelineBuilder':
+    def for_types(self, types: List[Type]) -> "TypeGenerationPipelineBuilder":
         self._types = types
         return self
 
-    def with_type_overrides(self, type_overrides: Dict[Type, Type]) -> 'TypeGenerationPipelineBuilder':
+    def with_type_overrides(
+        self, type_overrides: Dict[Type, Type]
+    ) -> "TypeGenerationPipelineBuilder":
         self._type_overrides = type_overrides
         return self
 
-    def convert_field_names_to_camel_case(self) -> 'TypeGenerationPipelineBuilder':
+    def convert_field_names_to_camel_case(self) -> "TypeGenerationPipelineBuilder":
         self._case_format = CaseFormat.CAMEL_CASE
         return self
 
-    def to_file(self, path: str | Path) -> 'TypeGenerationPipelineBuilder':
+    def to_file(self, path: str | Path) -> "TypeGenerationPipelineBuilder":
         self._output_file = path
         return self
 
-    def with_parsers(self, parsers: List[AbstractClassParser]) -> 'TypeGenerationPipelineBuilder':
+    def with_parsers(
+        self, parsers: List[AbstractClassParser]
+    ) -> "TypeGenerationPipelineBuilder":
         self._class_parsers = parsers
         return self
 

--- a/py2ts_generator/generation_pipeline/typescript_generation_pipeline_builder.py
+++ b/py2ts_generator/generation_pipeline/typescript_generation_pipeline_builder.py
@@ -1,9 +1,10 @@
 from pathlib import Path
-from typing import List, Type, Dict, Optional, Union
+from typing import List, Self, Type, Dict, Optional
 
 from py2ts_generator.generation_pipeline.typescript_generation_pipeline import (
     TypeGenerationPipeline,
 )
+from py2ts_generator.model_parser.class_parsers.abstract_class_parser import AbstractClassParser
 from py2ts_generator.typescript_model_compiler.typescript_model_compiler import (
     CaseFormat,
 )
@@ -17,35 +18,40 @@ class NoOutputFileDefined(Exception):
 
 
 class TypeGenerationPipelineBuilder:
-    def __init__(self):
+    def __init__(self) -> None:
         self._types: List[Type] = []
         self._type_overrides: Dict[Type, Type] = {}
         self._case_format: CaseFormat = CaseFormat.KEEP_CASING
-        self._output_file: Optional[Union[str, Path]] = None
+        self._output_file: Optional[str | Path] = None
+        self._class_parsers: Optional[List[AbstractClassParser]] = None
 
-    def for_types(self, types):
-        # type: (List[Type])->TypeGenerationPipelineBuilder
+    def for_types(self, types: List[Type]) -> Self:
         self._types = types
         return self
 
-    def with_type_overrides(self, type_overrides):
-        # type: (Dict[Type, Type])->TypeGenerationPipelineBuilder
+    def with_type_overrides(self, type_overrides: Dict[Type, Type]) -> Self:
         self._type_overrides = type_overrides
         return self
 
-    def convert_field_names_to_camel_case(self):
-        # type: ()->TypeGenerationPipelineBuilder
+    def convert_field_names_to_camel_case(self) -> Self:
         self._case_format = CaseFormat.CAMEL_CASE
         return self
 
-    def to_file(self, path):
-        # type: (Union[str, Path])->TypeGenerationPipelineBuilder
+    def to_file(self, path: str | Path) -> Self:
         self._output_file = path
+        return self
+    
+    def with_parsers(self, parsers: List[AbstractClassParser]) -> Self:
+        self._class_parsers = parsers
         return self
 
     def build(self) -> TypeGenerationPipeline:
         if not self._output_file:
             raise NoOutputFileDefined()
         return TypeGenerationPipeline(
-            self._types, self._type_overrides, self._case_format, self._output_file
+            self._types, 
+            self._type_overrides, 
+            self._case_format, 
+            self._output_file,
+            self._class_parsers,
         )

--- a/py2ts_generator/generation_pipeline/typescript_generation_pipeline_builder.py
+++ b/py2ts_generator/generation_pipeline/typescript_generation_pipeline_builder.py
@@ -4,7 +4,9 @@ from typing import List, Self, Type, Dict, Optional
 from py2ts_generator.generation_pipeline.typescript_generation_pipeline import (
     TypeGenerationPipeline,
 )
-from py2ts_generator.model_parser.class_parsers.abstract_class_parser import AbstractClassParser
+from py2ts_generator.model_parser.class_parsers.abstract_class_parser import (
+    AbstractClassParser,
+)
 from py2ts_generator.typescript_model_compiler.typescript_model_compiler import (
     CaseFormat,
 )
@@ -40,7 +42,7 @@ class TypeGenerationPipelineBuilder:
     def to_file(self, path: str | Path) -> Self:
         self._output_file = path
         return self
-    
+
     def with_parsers(self, parsers: List[AbstractClassParser]) -> Self:
         self._class_parsers = parsers
         return self
@@ -49,9 +51,9 @@ class TypeGenerationPipelineBuilder:
         if not self._output_file:
             raise NoOutputFileDefined()
         return TypeGenerationPipeline(
-            self._types, 
-            self._type_overrides, 
-            self._case_format, 
+            self._types,
+            self._type_overrides,
+            self._case_format,
             self._output_file,
             self._class_parsers,
         )

--- a/py2ts_generator/generation_pipeline/typescript_generation_pipeline_builder.py
+++ b/py2ts_generator/generation_pipeline/typescript_generation_pipeline_builder.py
@@ -27,23 +27,23 @@ class TypeGenerationPipelineBuilder:
         self._output_file: Optional[str | Path] = None
         self._class_parsers: Optional[List[AbstractClassParser]] = None
 
-    def for_types(self, types: List[Type]) -> Self:
+    def for_types(self, types: List[Type]) -> 'TypeGenerationPipelineBuilder':
         self._types = types
         return self
 
-    def with_type_overrides(self, type_overrides: Dict[Type, Type]) -> Self:
+    def with_type_overrides(self, type_overrides: Dict[Type, Type]) -> 'TypeGenerationPipelineBuilder':
         self._type_overrides = type_overrides
         return self
 
-    def convert_field_names_to_camel_case(self) -> Self:
+    def convert_field_names_to_camel_case(self) -> 'TypeGenerationPipelineBuilder':
         self._case_format = CaseFormat.CAMEL_CASE
         return self
 
-    def to_file(self, path: str | Path) -> Self:
+    def to_file(self, path: str | Path) -> 'TypeGenerationPipelineBuilder':
         self._output_file = path
         return self
 
-    def with_parsers(self, parsers: List[AbstractClassParser]) -> Self:
+    def with_parsers(self, parsers: List[AbstractClassParser]) -> 'TypeGenerationPipelineBuilder':
         self._class_parsers = parsers
         return self
 

--- a/py2ts_generator/model_parser/model_parser.py
+++ b/py2ts_generator/model_parser/model_parser.py
@@ -279,5 +279,5 @@ class ModelParser:
         except AttributeError:
             return ""
         if isinstance(attr, Enum):
-            return attr.name
+            return attr.name  # type: ignore
         return cast(str, attr)


### PR DESCRIPTION
Closes #10 

Adds:
- `class_parsers` argument to `TypeGenerationPipeline`, allowing to set which class parsers to use.
- `TypeGenerationPipelineBuilder.with_parsers` which sets the above attribute.

Fixes:
- MyPy workflow not targeting full source code
- Type errors in `model_parser.py`